### PR TITLE
Fix x_inputs Empty Array in List ValueError

### DIFF
--- a/drivers/prodriver.py
+++ b/drivers/prodriver.py
@@ -690,7 +690,7 @@ class ProDriver(RookieDriver):
                 x_inputs.append(x_in)
                 x_targets.append(x_tar)
 
-        if len(y_inputs) > 0 and len(x_inputs):
+        if len(y_inputs) > 0 and len(x_inputs) and len(np.vstack(x_inputs)):
             y_inputs_all = np.vstack(y_inputs)
             y_targets_all = np.vstack(y_targets)
             x_inputs_all = np.vstack(x_inputs)


### PR DESCRIPTION
Under certain random seeds I've found `x_inputs` to have the value:
```
[array([], shape=(0, 5), dtype=float64)]
```

This has a length of 1 which will pass the `len(x_inputs)` check but raise an error on 
```
self.track_grip_model_x.fit(x_inputs_all, x_targets_all)
```
ValueError: Found array with 0 sample(s) (shape=(0, 5)) while a minimum of 1 is required.

Adding another check to see if `len(np.vstack(x_inputs))` is 0 solves this problem.